### PR TITLE
Add metrics drift tracker script

### DIFF
--- a/tools/drift_tracker_log.json
+++ b/tools/drift_tracker_log.json
@@ -1,0 +1,142 @@
+[
+  {
+    "timestamp": "2024-05-01T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.65,
+      "symbolic_density": 0.7,
+      "divergence_space": 0.5
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.65,
+      "symbolic_density": 0.7,
+      "divergence_space": 0.5
+    },
+    "flexibility_pulse": 0.0
+  },
+  {
+    "timestamp": "2024-05-05T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.655,
+      "symbolic_density": 0.71,
+      "divergence_space": 0.505
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.655,
+      "symbolic_density": 0.71,
+      "divergence_space": 0.505
+    },
+    "flexibility_pulse": 0.0
+  },
+  {
+    "timestamp": "2024-05-10T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.67,
+      "symbolic_density": 0.725,
+      "divergence_space": 0.515
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.6633333333333334,
+      "symbolic_density": 0.7166666666666667,
+      "divergence_space": 0.51
+    },
+    "flexibility_pulse": 0.006666666666666636
+  },
+  {
+    "timestamp": "2024-05-15T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.675,
+      "symbolic_density": 0.72,
+      "divergence_space": 0.515
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.665,
+      "symbolic_density": 0.715,
+      "divergence_space": 0.51
+    },
+    "flexibility_pulse": 0.006666666666666672
+  },
+  {
+    "timestamp": "2024-05-20T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.6799999999999999,
+      "symbolic_density": 0.725,
+      "divergence_space": 0.52
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.67,
+      "symbolic_density": 0.72,
+      "divergence_space": 0.514
+    },
+    "flexibility_pulse": 0.006999999999999969
+  },
+  {
+    "timestamp": "2024-05-25T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.695,
+      "symbolic_density": 0.745,
+      "divergence_space": 0.54
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.6749999999999999,
+      "symbolic_density": 0.725,
+      "divergence_space": 0.52
+    },
+    "flexibility_pulse": 0.020000000000000018
+  },
+  {
+    "timestamp": "2024-05-30T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.705,
+      "symbolic_density": 0.755,
+      "divergence_space": 0.555
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.6799999999999999,
+      "symbolic_density": 0.7299999999999999,
+      "divergence_space": 0.5257142857142857
+    },
+    "flexibility_pulse": 0.026428571428571506
+  },
+  {
+    "timestamp": "2024-06-04T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.715,
+      "symbolic_density": 0.765,
+      "divergence_space": 0.565
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.6900000000000001,
+      "symbolic_density": 0.74,
+      "divergence_space": 0.5357142857142857
+    },
+    "flexibility_pulse": 0.026428571428571395
+  },
+  {
+    "timestamp": "2024-06-09T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.725,
+      "symbolic_density": 0.775,
+      "divergence_space": 0.575
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.7000000000000001,
+      "symbolic_density": 0.7485714285714284,
+      "divergence_space": 0.5457142857142857
+    },
+    "flexibility_pulse": 0.026904761904761914
+  },
+  {
+    "timestamp": "2024-06-14T12:00:00",
+    "avg_7_day": {
+      "interpretive_bandwidth": 0.735,
+      "symbolic_density": 0.785,
+      "divergence_space": 0.585
+    },
+    "avg_30_day": {
+      "interpretive_bandwidth": 0.7085714285714284,
+      "symbolic_density": 0.7571428571428571,
+      "divergence_space": 0.5557142857142857
+    },
+    "flexibility_pulse": 0.027857142857142914
+  }
+]

--- a/tools/metrics_drift_tracker.py
+++ b/tools/metrics_drift_tracker.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Temporal Drift Tracker
+========================
+
+Usage:
+  python tools/metrics_drift_tracker.py [--log PATH] [--output PATH] [--plot]
+
+This script reads a monitoring log (default: tools/monitor_log.json) containing
+timestamped live metrics:
+ - interpretive_bandwidth
+ - symbolic_density
+ - divergence_space
+
+It performs sliding window analysis over 7-day and 30-day intervals to detect
+changes in interpretive flexibility. A "Flexibility Pulse" score represents the
+short-term trend relative to the longer baseline. Results are saved to
+``tools/drift_tracker_log.json`` and an optional plot may be displayed.
+"""
+
+import argparse
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+  import matplotlib.pyplot as plt
+except Exception:  # matplotlib is optional
+  plt = None
+
+
+METRICS = ["interpretive_bandwidth", "symbolic_density", "divergence_space"]
+
+
+def load_log(path: Path):
+  """Load monitoring data and parse timestamps."""
+  with path.open() as f:
+    data = json.load(f)
+
+  for entry in data:
+    entry["timestamp"] = datetime.fromisoformat(entry["timestamp"])
+  data.sort(key=lambda x: x["timestamp"])
+  return data
+
+
+def average(entries):
+  """Compute average metrics for a list of entries."""
+  if not entries:
+    return {m: 0 for m in METRICS}
+  result = {m: 0.0 for m in METRICS}
+  for e in entries:
+    for m in METRICS:
+      result[m] += e.get(m, 0)
+  count = len(entries)
+  return {m: result[m] / count for m in METRICS}
+
+
+def analyze(entries):
+  """Return trend data with 7-day, 30-day averages and flexibility pulse."""
+  results = []
+  for entry in entries:
+    t = entry["timestamp"]
+    win7 = [e for e in entries if t - timedelta(days=7) <= e["timestamp"] <= t]
+    win30 = [e for e in entries if t - timedelta(days=30) <= e["timestamp"] <= t]
+    avg7 = average(win7)
+    avg30 = average(win30)
+
+    pulse = sum((avg7[m] - avg30[m]) for m in METRICS) / len(METRICS)
+
+    results.append({
+        "timestamp": t.isoformat(),
+        "avg_7_day": avg7,
+        "avg_30_day": avg30,
+        "flexibility_pulse": pulse
+    })
+  return results
+
+
+def save_results(results, path: Path):
+  with path.open("w") as f:
+    json.dump(results, f, indent=2)
+
+
+
+def plot_pulse(results):
+  if plt is None:
+    print("Matplotlib not available; skipping plot.")
+    return
+  times = [datetime.fromisoformat(r["timestamp"]) for r in results]
+  pulse = [r["flexibility_pulse"] for r in results]
+  plt.figure(figsize=(10, 4))
+  plt.plot(times, pulse, marker="o")
+  plt.xlabel("Time")
+  plt.ylabel("Flexibility Pulse")
+  plt.title("Temporal Flexibility Pulse")
+  plt.grid(True)
+  plt.tight_layout()
+  plt.show()
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Temporal Drift Tracker")
+  parser.add_argument("--log", default="tools/monitor_log.json",
+                      help="Path to monitor_log.json")
+  parser.add_argument("--output", default="tools/drift_tracker_log.json",
+                      help="Where to store drift analysis")
+  parser.add_argument("--plot", action="store_true",
+                      help="Display a matplotlib plot of the pulse")
+  args = parser.parse_args()
+
+  log_path = Path(args.log)
+  if not log_path.exists():
+    raise FileNotFoundError(f"Monitor log not found: {log_path}")
+
+  entries = load_log(log_path)
+  results = analyze(entries)
+  save_results(results, Path(args.output))
+  print(f"Drift data written to {args.output}")
+
+  if args.plot:
+    plot_pulse(results)
+
+
+if __name__ == "__main__":
+  main()

--- a/tools/monitor_log.json
+++ b/tools/monitor_log.json
@@ -1,0 +1,12 @@
+[
+  {"timestamp": "2024-05-01T12:00:00", "interpretive_bandwidth": 0.65, "symbolic_density": 0.70, "divergence_space": 0.50},
+  {"timestamp": "2024-05-05T12:00:00", "interpretive_bandwidth": 0.66, "symbolic_density": 0.72, "divergence_space": 0.51},
+  {"timestamp": "2024-05-10T12:00:00", "interpretive_bandwidth": 0.68, "symbolic_density": 0.73, "divergence_space": 0.52},
+  {"timestamp": "2024-05-15T12:00:00", "interpretive_bandwidth": 0.67, "symbolic_density": 0.71, "divergence_space": 0.51},
+  {"timestamp": "2024-05-20T12:00:00", "interpretive_bandwidth": 0.69, "symbolic_density": 0.74, "divergence_space": 0.53},
+  {"timestamp": "2024-05-25T12:00:00", "interpretive_bandwidth": 0.70, "symbolic_density": 0.75, "divergence_space": 0.55},
+  {"timestamp": "2024-05-30T12:00:00", "interpretive_bandwidth": 0.71, "symbolic_density": 0.76, "divergence_space": 0.56},
+  {"timestamp": "2024-06-04T12:00:00", "interpretive_bandwidth": 0.72, "symbolic_density": 0.77, "divergence_space": 0.57},
+  {"timestamp": "2024-06-09T12:00:00", "interpretive_bandwidth": 0.73, "symbolic_density": 0.78, "divergence_space": 0.58},
+  {"timestamp": "2024-06-14T12:00:00", "interpretive_bandwidth": 0.74, "symbolic_density": 0.79, "divergence_space": 0.59}
+]


### PR DESCRIPTION
## Summary
- add metrics_drift_tracker.py for sliding-window analysis of interpretive metrics
- provide sample monitor_log.json data
- generate drift_tracker_log.json via script

## Testing
- `python3 tools/metrics_drift_tracker.py --output tools/drift_tracker_log.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ab990bb0832dba78c9c6858a8229