### PR TITLE
Add Wonder Index calculator script

### DIFF
--- a/tools/wonder_index_calculator.py
+++ b/tools/wonder_index_calculator.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Wonder Index Calculator
+=======================
+
+Usage:
+  python tools/wonder_index_calculator.py [--drift DRIFT_LOG] [--div DIV_LOG]
+                                         [--signals SIGNALS_JSON]
+                                         [--output OUT_FILE] [--plot]
+
+This script synthesizes interpretive metrics from the drift tracker,
+instance divergence log, and optional Wonder Signals to produce a
+composite Wonder Index (0-1) for each timestamp. Metrics are
+min-max normalised and averaged. Optionally a matplotlib plot of the
+index trend is displayed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from datetime import datetime
+
+from typing import Dict, List
+
+try:
+    import matplotlib.pyplot as plt  # type: ignore
+except Exception:  # matplotlib optional
+    plt = None
+
+
+MetricDict = Dict[str, float]
+
+
+def load_drift(path: Path) -> Dict[str, MetricDict]:
+    """Load 7-day averages from drift tracker log."""
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    result: Dict[str, MetricDict] = {}
+    for entry in data:
+        ts = entry.get("timestamp")
+        avg = entry.get("avg_7_day", {})
+        if ts:
+            result[ts] = {
+                "interpretive_bandwidth": avg.get("interpretive_bandwidth"),
+                "symbolic_density": avg.get("symbolic_density"),
+                "divergence": avg.get("divergence_space"),
+            }
+    return result
+
+
+def load_divergence(path: Path) -> Dict[str, MetricDict]:
+    """Return divergence metric averaged across matrix values."""
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    result: Dict[str, MetricDict] = {}
+    for entry in data:
+        ts = entry.get("timestamp")
+        matrix = entry.get("matrix")
+        if ts and matrix:
+            n = len(matrix)
+            values: List[float] = []
+            for i in range(n):
+                for j in range(i + 1, n):
+                    values.append(matrix[i][j])
+            avg = sum(values) / len(values) if values else 0.0
+            result[ts] = {"divergence": avg}
+    return result
+
+
+def load_wonder_signals(path: Path) -> Dict[str, MetricDict]:
+    """Load optional Wonder Signals JSON (timestamp -> value)."""
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    result: Dict[str, MetricDict] = {}
+    for entry in data:
+        ts = entry.get("timestamp")
+        val = entry.get("wonder_signal")
+        if ts and val is not None:
+            result[ts] = {"wonder_signal": float(val)}
+    return result
+
+
+def combine_metrics(*sources: Dict[str, MetricDict]) -> Dict[str, MetricDict]:
+    """Merge metric dictionaries keyed by timestamp."""
+    combined: Dict[str, MetricDict] = {}
+    for source in sources:
+        for ts, metrics in source.items():
+            combined.setdefault(ts, {}).update(metrics)
+    return combined
+
+
+def normalise(entries: Dict[str, MetricDict]) -> Dict[str, MetricDict]:
+    """Min-max normalise metrics across all timestamps."""
+    metrics = {m for v in entries.values() for m in v}
+    ranges: Dict[str, tuple[float, float]] = {}
+    for m in metrics:
+        values = [v[m] for v in entries.values() if m in v and v[m] is not None]
+        if not values:
+            continue
+        ranges[m] = (min(values), max(values))
+    normed: Dict[str, MetricDict] = {}
+    for ts, vals in entries.items():
+        normed_vals: MetricDict = {}
+        for m, value in vals.items():
+            low, high = ranges.get(m, (0.0, 0.0))
+            if high != low:
+                normed_vals[m] = (value - low) / (high - low)
+            else:
+                normed_vals[m] = 0.0
+        normed[ts] = normed_vals
+    return normed
+
+
+def compute_wonder_index(normed: Dict[str, MetricDict]) -> List[dict]:
+    """Return sorted list of entries with Wonder Index."""
+    results = []
+    for ts, metrics in normed.items():
+        values = [v for v in metrics.values() if v is not None]
+        index = sum(values) / len(values) if values else 0.0
+        result = {
+            "timestamp": ts,
+            **{f"{k}_norm": v for k, v in metrics.items()},
+            "wonder_index": index,
+        }
+        results.append(result)
+    results.sort(key=lambda x: x["timestamp"])
+    return results
+
+
+def save_results(results: List[dict], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+
+
+def plot_index(results: List[dict]) -> None:
+    if plt is None:
+        print("Matplotlib not available; skipping plot.")
+        return
+    times = [datetime.fromisoformat(r["timestamp"]) for r in results]
+    values = [r["wonder_index"] for r in results]
+    plt.figure(figsize=(10, 4))
+    plt.plot(times, values, marker="o")
+    plt.xlabel("Time")
+    plt.ylabel("Wonder Index")
+    plt.title("Wonder Index Trend")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compute Wonder Index")
+    parser.add_argument("--drift", default="tools/drift_tracker_log.json")
+    parser.add_argument("--div", default="tools/divergence_log.json")
+    parser.add_argument("--signals", default="tools/wonder_signals.json")
+    parser.add_argument("--output", default="tools/wonder_index_log.json")
+    parser.add_argument("--plot", action="store_true")
+    args = parser.parse_args()
+
+    drift = load_drift(Path(args.drift))
+    divergence = load_divergence(Path(args.div))
+    signals = load_wonder_signals(Path(args.signals))
+
+    combined = combine_metrics(drift, divergence, signals)
+    normed = normalise(combined)
+    results = compute_wonder_index(normed)
+
+    save_results(results, Path(args.output))
+    print(f"Wonder Index written to {args.output}")
+
+    if args.plot:
+        plot_index(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/wonder_index_log.json
+++ b/tools/wonder_index_log.json
@@ -1,0 +1,77 @@
+[
+  {
+    "timestamp": "2024-05-01T12:00:00",
+    "interpretive_bandwidth_norm": 0.0,
+    "symbolic_density_norm": 0.0,
+    "divergence_norm": 0.7258064516129032,
+    "wonder_index": 0.24193548387096775
+  },
+  {
+    "timestamp": "2024-05-05T12:00:00",
+    "interpretive_bandwidth_norm": 0.05882352941176478,
+    "symbolic_density_norm": 0.11764705882352941,
+    "divergence_norm": 0.7419354838709679,
+    "wonder_index": 0.306135357368754
+  },
+  {
+    "timestamp": "2024-05-10T12:00:00",
+    "interpretive_bandwidth_norm": 0.23529411764705913,
+    "symbolic_density_norm": 0.29411764705882354,
+    "divergence_norm": 0.7741935483870969,
+    "wonder_index": 0.4345351043643266
+  },
+  {
+    "timestamp": "2024-05-15T12:00:00",
+    "interpretive_bandwidth_norm": 0.29411764705882393,
+    "symbolic_density_norm": 0.23529411764705882,
+    "divergence_norm": 0.7741935483870969,
+    "wonder_index": 0.4345351043643266
+  },
+  {
+    "timestamp": "2024-05-20T12:00:00",
+    "interpretive_bandwidth_norm": 0.35294117647058737,
+    "symbolic_density_norm": 0.29411764705882354,
+    "divergence_norm": 0.7903225806451615,
+    "wonder_index": 0.4791271347248574
+  },
+  {
+    "timestamp": "2024-05-25T12:00:00",
+    "interpretive_bandwidth_norm": 0.5294117647058817,
+    "symbolic_density_norm": 0.5294117647058824,
+    "divergence_norm": 0.8548387096774196,
+    "wonder_index": 0.6378874130297278
+  },
+  {
+    "timestamp": "2024-05-30T12:00:00",
+    "interpretive_bandwidth_norm": 0.6470588235294114,
+    "symbolic_density_norm": 0.6470588235294118,
+    "divergence_norm": 0.9032258064516132,
+    "wonder_index": 0.7324478178368121
+  },
+  {
+    "timestamp": "2024-06-04T12:00:00",
+    "interpretive_bandwidth_norm": 0.7647058823529409,
+    "symbolic_density_norm": 0.7647058823529411,
+    "divergence_norm": 0.9354838709677419,
+    "wonder_index": 0.8216318785578746
+  },
+  {
+    "timestamp": "2024-06-09T12:00:00",
+    "interpretive_bandwidth_norm": 0.8823529411764705,
+    "symbolic_density_norm": 0.8823529411764706,
+    "divergence_norm": 0.9677419354838709,
+    "wonder_index": 0.9108159392789373
+  },
+  {
+    "timestamp": "2024-06-10T12:00:00",
+    "divergence_norm": 0.0,
+    "wonder_index": 0.0
+  },
+  {
+    "timestamp": "2024-06-14T12:00:00",
+    "interpretive_bandwidth_norm": 1.0,
+    "symbolic_density_norm": 1.0,
+    "divergence_norm": 1.0,
+    "wonder_index": 1.0
+  }
+]


### PR DESCRIPTION
## Summary
- implement `tools/wonder_index_calculator.py` for computing a composite Wonder Index
- generate initial `tools/wonder_index_log.json`

## Testing
- `ruff check tools/wonder_index_calculator.py`
- `python tools/wonder_index_calculator.py --output tools/wonder_index_log.json`


------
https://chatgpt.com/codex/tasks/task_e_6849c5cda254832daeec57a8ce510261