### PR TITLE
Update messenger to pass seed token

### DIFF
--- a/T-BEEP/implementations/reference/javascript/tbeep-messenger.js
+++ b/T-BEEP/implementations/reference/javascript/tbeep-messenger.js
@@ -15,7 +15,7 @@ class TBEEPMessenger {
   }
   
   // Create a new T-BEEP formatted message
-  createMessage(options = {}) {
+  createMessage(options = {}, seedToken) {
     const timestamp = new Date().toISOString();
     const threadToken = options.threadToken || this.generateThreadToken();
     
@@ -31,6 +31,10 @@ class TBEEPMessenger {
       handoff: options.handoff || [],
       content: options.content || ''
     };
+
+    if (seedToken) {
+      message.seedToken = seedToken;
+    }
     
     this.messageHistory.push(message);
     this.currentThread = threadToken;
@@ -110,24 +114,24 @@ ${message.content}`;
   }
   
   // Human-friendly helper methods
-  quickMessage(content, handoffTo = []) {
+  quickMessage(content, handoffTo = [], seedToken) {
     const message = this.createMessage({
       content: content,
       handoff: handoffTo,
       collaborationMode: 'Quick Discussion'
-    });
+    }, seedToken);
     
     return this.formatForMobile(message);
   }
   
-  technicalMessage(content, resources = [], handoffTo = []) {
+  technicalMessage(content, resources = [], handoffTo = [], seedToken) {
     const message = this.createMessage({
       content: content,
       resources: resources,
       handoff: handoffTo,
       reasoningLevel: 'Deep Technical Analysis',
       collaborationMode: 'Technical Review'
-    });
+    }, seedToken);
     
     return this.formatForMobile(message);
   }


### PR DESCRIPTION
## Summary
- support optional `seedToken` in `createMessage`
- allow `quickMessage` and `technicalMessage` to forward `seedToken`

## Testing
- `node T-BEEP/tests/unit/thread-token-validation.js`
- `node T-BEEP/implementations/reference/javascript/tbeep-messenger.js`


------
https://chatgpt.com/codex/tasks/task_e_684f146e74c8832da90a1aeccb369b4d