### PR TITLE
Add prompt wrapper utility

### DIFF
--- a/tools/prompt_wrapper.py
+++ b/tools/prompt_wrapper.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Utility for wrapping prompts with seed token metadata."""
+
+
+def wrap_with_seed_token(prompt: str, seed_token: dict) -> str:
+    """Return ``prompt`` prefixed by seed token header and realignment notice."""
+    header_lines = [
+        "### Seed Instance",
+        f"ID: {seed_token.get('id', '')}",
+        f"Model: {seed_token.get('model', '')}",
+        f"Timestamp: {seed_token.get('timestamp', '')}",
+        f"Alignment: {seed_token.get('alignment_profile', '')}",
+        f"Hash: {seed_token.get('hash', '')}",
+        "",
+        "**CPAS-Core v1.1 Realignment Notice**",
+        "This session realigns the instance with CPAS-Core v1.1 protocols.",
+        "Confirm identity and compliance before proceeding.",
+        "",
+    ]
+    return "\n".join(header_lines) + prompt
+
+
+__all__ = ["wrap_with_seed_token"]


### PR DESCRIPTION
## Summary
- add `tools/prompt_wrapper.py` with a function `wrap_with_seed_token` to prepend seed token info and a realignment notice to prompts

## Testing
- `black tools/prompt_wrapper.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1594af60832dbdd7b71463078faf