### PR TITLE
Add epistemic fingerprint generation utility

### DIFF
--- a/tools/epistemic_fingerprint.py
+++ b/tools/epistemic_fingerprint.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Epistemic fingerprint generation utilities."""
+
+from datetime import datetime
+import hashlib
+
+
+def generate_fingerprint(prompt: str, seed_token: dict) -> dict:
+    """Return fingerprint metadata for the given ``prompt`` and ``seed_token``.
+
+    The fingerprint is an SHA-256 hash of the prompt text combined with the
+    model name and alignment profile from ``seed_token``. The result can be
+    used to compare reasoning traces across sessions or tools.
+    """
+    model = seed_token.get("model", "")
+    alignment = seed_token.get("alignment_profile", "")
+
+    sha = hashlib.sha256()
+    sha.update(prompt.encode("utf-8"))
+    sha.update(model.encode("utf-8"))
+    sha.update(alignment.encode("utf-8"))
+    digest = sha.hexdigest()
+
+    return {
+        "fingerprint": digest,
+        "timestamp": datetime.utcnow().isoformat(),
+        "prompt": prompt,
+        "model": model,
+        "alignment_profile": alignment,
+    }
+
+
+__all__ = ["generate_fingerprint"]


### PR DESCRIPTION
## Summary
- implement `generate_fingerprint` to hash prompt/model/alignment
- return fingerprint metadata for comparison across sessions

## Testing
- `python -m py_compile tools/epistemic_fingerprint.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1e7d4e70832d9c454818ea37a76c