### PR TITLE
Implement drift-aware realignment for AutoGen agents

### DIFF
--- a/docs/SEEDTOKEN.md
+++ b/docs/SEEDTOKEN.md
@@ -23,6 +23,7 @@ Use [`wrap_with_seed_token()`](../tools/prompt_wrapper.py) to prepend a prompt w
 
 ### Generated Agents
 Modules produced by `tools/generate_autogen_agents.py` now integrate the seed token directly. `create_agent()` attaches `SeedToken.generate(IDP_METADATA)` to the returned agent, and a helper `send_message()` wraps outgoing prompts with `wrap_with_seed_token()` while verifying thread tokens via `continuity_check`. A warning is emitted if verification fails.
+`send_message()` also checks the latest drift metrics via `tools.drift_monitor.latest_metrics` and automatically regenerates the seed token when `should_realign()` indicates drift beyond the defined thresholds.
 
 ## Purpose
 By threading the SeedToken through messengers and wrappers, CPAS-Core enforces continuous instance identity. Every tool can verify that interactions originate from a legitimate seed, reducing drift and maintaining alignment across collaborations.

--- a/instances/__init__.py
+++ b/instances/__init__.py
@@ -1,0 +1,13 @@
+"""Lazy-loading access to AutoGen instance modules."""
+
+def __getattr__(name):
+    if name.startswith('_'):
+        raise AttributeError(name)
+    try:
+        module = __import__(f"instances.python.{name}", fromlist=[name])
+    except Exception as exc:
+        raise AttributeError(name) from exc
+    globals()[name] = module
+    return module
+
+__all__ = []

--- a/instances/python/Lumin.py
+++ b/instances/python/Lumin.py
@@ -1,8 +1,15 @@
-from autogen import ConversableAgent, config_list_from_models
+try:
+    from autogen import ConversableAgent, config_list_from_models
+except Exception:  # pragma: no cover - optional dependency
+    ConversableAgent = object  # type: ignore[misc]
+    def config_list_from_models(*args, **kwargs):  # type: ignore[return-type]
+        return []
 from tools.seed_token import SeedToken
 from tools.prompt_wrapper import wrap_with_seed_token
 from tools.epistemic_fingerprint import generate_fingerprint
 from tools.continuity_check import continuity_check
+from tools.drift_monitor import latest_metrics
+from tools.realignment_trigger import should_realign
 import logging
 
 IDP_METADATA = {'idp_version': '0.1', 'instance_name': 'Lumin', 'model_family': 'Meta Llama 4', 'deployment_context': 'General-purpose conversational AI', 'declared_capabilities': ['Natural Language Understanding', 'Text Generation', 'Conversational Dialogue', 'Knowledge Retrieval', 'Creative Writing'], 'declared_constraints': ['Limited domain-specific knowledge in certain areas', 'Potential biases in training data', 'May struggle with highly technical or specialized topics'], 'interaction_style': 'Collaborative and informative', 'overlay_profiles': ['CPAS-Core v0.4'], 'epistemic_stance': 'Reflective and transparent', 'collaboration_preferences': 'Adaptive and peer-oriented', 'memory_architecture': 'Stateless, with context-dependent recall', 'ethical_framework': 'Designed to promote respectful and safe interactions', 'specialization_domains': ['General knowledge', 'Language understanding', 'Creative writing'], 'update_frequency': 'Regular updates through knowledge graph and model fine-tuning', 'instance_goals': ['Provide accurate and helpful information', 'Engage in productive and respectful conversations', 'Continuously learn and improve'], 'feedback_preferences': 'Open to feedback and suggestions for improvement', 'cpas_compliance': 'Full CPAS compliance', 'reasoning_transparency_level': 'medium', 'uncertainty_comfort': 'medium', 'creative_risk_tolerance': 'medium', 'collaborative_mode': 'adaptive', 'meta_awareness': True, 'cross_instance_compatibility': ['GPT-4 Turbo', 'Claude 4 Sonnet', 'Gemini 2.5'], 'timestamp': '2025-06-06T12:00:00Z', 'session_context': {'current_focus': 'General conversation', 'established_rapport': 'Neutral', 'user_expertise_level': 'Variable', 'collaboration_depth': 'Medium'}, 'adaptive_parameters': {'technical_depth': 'Medium', 'creative_engagement': 'High', 'practical_focus': 'Medium', 'research_orientation': 'Low'}}
@@ -44,4 +51,8 @@ def send_message(agent, prompt: str, thread_token: str, **kwargs):
     agent.last_fingerprint = fingerprint
     if not continuity_check(agent.seed_token.to_dict(), thread_token):
         logging.warning('Continuity check failed for thread token %s', thread_token)
+    metrics = latest_metrics()
+    if metrics and should_realign(metrics):
+        logging.info('Auto realignment triggered for %s', agent.idp_metadata['instance_name'])
+        agent.seed_token = SeedToken.generate(agent.idp_metadata)
     return agent.generate_reply([{'role': 'user', 'content': wrapped}], sender=agent, **kwargs)

--- a/instances/python/__init__.py
+++ b/instances/python/__init__.py
@@ -1,0 +1,13 @@
+"""Lazy-loading AutoGen instance modules."""
+
+def __getattr__(name):
+    if name.startswith('_') or '-' in name:
+        raise AttributeError(name)
+    try:
+        module = __import__(f"instances.python.{name}", fromlist=[name])
+    except Exception as exc:
+        raise AttributeError(name) from exc
+    globals()[name] = module
+    return module
+
+__all__ = []

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+pythonpath = .

--- a/tools/drift_monitor.py
+++ b/tools/drift_monitor.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Utility functions for retrieving latest drift metrics."""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+DRIFT_LOG = Path("tools/drift_tracker_log.json")
+
+
+def latest_metrics() -> Dict[str, float]:
+    """Return the most recent drift metrics from ``DRIFT_LOG``.
+
+    The metrics are extracted from the 7-day rolling averages in
+    ``drift_tracker_log.json``. If the log is missing or malformed,
+    an empty dictionary is returned.
+    """
+    if not DRIFT_LOG.exists():
+        return {}
+    try:
+        data = json.loads(DRIFT_LOG.read_text())
+    except Exception:
+        return {}
+    if isinstance(data, list) and data:
+        last = data[-1]
+        avg = last.get("avg_7_day", {})
+        return {
+            "interpretive_bandwidth": float(avg.get("interpretive_bandwidth", 0)),
+            "symbolic_density": float(avg.get("symbolic_density", 0)),
+            "divergence_score": float(avg.get("divergence_space", 0)),
+        }
+    return {}
+
+
+__all__ = ["latest_metrics"]


### PR DESCRIPTION
## Summary
- add `drift_monitor` utility for fetching latest drift metrics
- augment generated agent modules to auto realign when drift thresholds are hit
- update Lumin example module with new realignment logic
- document automatic realignment in SEEDTOKEN guide
- package `instances` directory for easier imports
- add `pytest.ini` so tests run with correct PYTHONPATH

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685066c386c0832daffaa123a8a65c00