### PR TITLE
Add unified monitoring dashboard

### DIFF
--- a/docs/dashboard_usage.md
+++ b/docs/dashboard_usage.md
@@ -1,6 +1,6 @@
 # Dynamic Dashboard Prototype
 
-`tools/dashboard.py` provides a lightweight Streamlit interface for real-time visualization of epistemic metrics.
+`tools/dashboard.py` provides a lightweight Streamlit interface for real-time visualization of epistemic metrics. The dashboard now consolidates multiple views including Flexibility Pulse, Wonder Index trends, emergence events and realignment indicators.
 
 ## Usage
 
@@ -9,4 +9,5 @@ streamlit run tools/dashboard.py
 ```
 
 The dashboard reads baseline values from `tools/baseline_metrics.json` and live metrics from `tools/monitor_log.json`.
-It highlights drift, signals potential rollback triggers, and offers a collaborative **Wonder Signals** text area.
+It also displays data from `tools/drift_tracker_log.json`, `tools/wonder_index_log.json` and `tools/emergence_log.json`.
+Drift metrics are checked against realignment thresholds and highlighted when thresholds are exceeded. A collaborative **Wonder Signals** text area is available for qualitative notes.


### PR DESCRIPTION
## Summary
- combine existing Streamlit views in `tools/dashboard.py`
- show Flexibility Pulse, Wonder Index and emergence events
- highlight realignment triggers using drift metrics
- document consolidated dashboard usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506a1820bc832d88ca14372cf8db69