### PR TITLE
Implement simple Flask API for T-BEEP messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Visualize the flexibility pulse by running:
 streamlit run dashboard.py
 ```
 
+### T-BEEP API Example
+
+An experimental Flask service in `tbeep_api.py` accepts and stores T-BEEP
+messages. Start the API with:
+
+```bash
+python tbeep_api.py
+```
+
+Messages can then be POSTed to `/api/v1/messages` and fetched by thread ID via
+`GET /api/v1/messages?thread_id=`.
+
 ### Metaphor Library Extension
 
 The **DKA-E metaphors**—focusing on persistent knowledge structures, dynamic evolution, and collaborative orchestration—are now housed within the [**Metaphor Library**](./metaphor-library/DKA-E/). These extend the core DKA module, offering symbolic depth for advanced use cases.

--- a/tbeep_api.py
+++ b/tbeep_api.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Simple Flask API for T-BEEP message storage."""
+
+from typing import Dict, List
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# In-memory message store keyed by thread token
+MESSAGE_STORE: Dict[str, List[dict]] = {}
+
+
+@app.route("/api/v1/messages", methods=["POST"])
+def post_message():
+    """Store a T-BEEP message in memory."""
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON"}), 400
+    thread_id = data.get("threadToken")
+    if not thread_id:
+        return jsonify({"error": "threadToken missing"}), 400
+    MESSAGE_STORE.setdefault(thread_id, []).append(data)
+    return jsonify({"status": "stored"}), 201
+
+
+@app.route("/api/v1/messages", methods=["GET"])
+def get_messages():
+    """Return messages for the given thread ID."""
+    thread_id = request.args.get("thread_id")
+    if not thread_id:
+        return jsonify({"error": "thread_id required"}), 400
+    return jsonify(MESSAGE_STORE.get(thread_id, []))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/test_tbeep_api.py
+++ b/tests/test_tbeep_api.py
@@ -1,0 +1,30 @@
+import json
+import builtins
+from tbeep_api import app, MESSAGE_STORE
+
+
+def test_post_and_get_message():
+    client = app.test_client()
+    MESSAGE_STORE.clear()
+    msg = {
+        "threadToken": "#TEST_001.0",
+        "instance": "Unit",
+        "reasoningLevel": "Detailed",
+        "confidence": "High",
+        "collaborationMode": "Discussion",
+        "timestamp": "2025-01-01T00:00:00Z",
+        "version": "#TEST.v1.0",
+        "content": "hello"
+    }
+    res = client.post("/api/v1/messages", json=msg)
+    assert res.status_code == 201
+    res = client.get("/api/v1/messages", query_string={"thread_id": "#TEST_001.0"})
+    assert res.status_code == 200
+    assert res.get_json() == [msg]
+
+
+def test_missing_thread_token():
+    client = app.test_client()
+    MESSAGE_STORE.clear()
+    res = client.post("/api/v1/messages", json={"content": "x"})
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add a lightweight Flask API (`tbeep_api.py`) to store T‑BEEP messages in memory
- document API usage in README
- test POST and GET endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506b307258832d93ce0c80769d87eb