### PR TITLE
Update dashboard instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ A modular standard for layered AI interaction, cross-instance collaboration, and
 Visualize the flexibility pulse by running:
 
 ```bash
-streamlit run dashboard.py
+streamlit run tools/dashboard.py
 ```
+
+The dashboard now includes a scrolling message feed and a right-hand metrics panel
+summarizing baseline drift and the wonder index across all active instances.
 
 ### T-BEEP API Example
 


### PR DESCRIPTION
## Summary
- fix dashboard command in README
- document new message feed and metrics panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850814eafa4832d94d7974a882743fd