### PR TITLE
Remove tracked environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ phase2-env/
 tools/drift_tracker_log.json
 
 phase3-env/
+
+autogen-cpas-env/
+**/__pycache__/


### PR DESCRIPTION
## Summary
- remove the large `autogen-cpas-env` folder
- ignore the environment and python cache directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685083f92c80832da4af9f603118c044