### PR TITLE
Remove unused builtins import

### DIFF
--- a/tests/test_tbeep_api.py
+++ b/tests/test_tbeep_api.py
@@ -1,5 +1,4 @@
 import json
-import builtins
 from tbeep_api import app, MESSAGE_STORE
 
 


### PR DESCRIPTION
## Summary
- delete unused `builtins` import from `tests/test_tbeep_api.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509ec810ac832db162c0a4788d9b7d