### PR TITLE
Add requirements and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ A modular standard for layered AI interaction, cross-instance collaboration, and
 - [**Compliance Tests**](./compliance-tests/)
 - [**Research & Reflections**](./docs/research/)
 
+## Installation
+
+Install the core dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
 ### Drift Monitoring Dashboard
 
 Visualize the flexibility pulse by running:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Flask
+streamlit
+pandas
+matplotlib
+sentence-transformers
+spacy
+scikit-learn
+numpy
+torch
+requests


### PR DESCRIPTION
## Summary
- list base packages in `requirements.txt`
- add quick install command in README

## Testing
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850b65c8ce0832d8c1c76b94081341e