### PR TITLE
Normalize log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ phase1-env/
 phase2-env/
 
 tools/*_log.json
-docs/examples/*.json
+docs/examples/*_log.json
 
 phase3-env/
 

--- a/docs/dashboard_usage.md
+++ b/docs/dashboard_usage.md
@@ -9,6 +9,6 @@ streamlit run ui/dashboard.py
 ```
 
 The dashboard reads baseline values from `docs/examples/baseline_metrics.json` and live metrics from `docs/examples/monitor_log.json`.
-It also displays data from `docs/examples/drift_tracker_log.json`, `docs/examples/wonder_index_log.json` and `tools/emergence_log.json`.
+It also displays data from `docs/examples/drift_tracker_log.json`, `docs/examples/wonder_index_log.json` and `docs/examples/emergence_log.json`.
 Drift metrics are checked against realignment thresholds and highlighted when thresholds are exceeded. A collaborative **Wonder Signals** text area is available for qualitative notes.
 You can additionally upload a metrics log in JSON format via the sidebar for ad-hoc drift analysis.

--- a/tools/baseline_metrics.py
+++ b/tools/baseline_metrics.py
@@ -56,7 +56,9 @@ def main():
         'divergence_space': divergence_space(texts, nlp),
     }
 
-    out_file = Path('baseline_metrics.json')
+    examples_dir = Path(__file__).resolve().parents[1] / 'docs' / 'examples'
+    examples_dir.mkdir(parents=True, exist_ok=True)
+    out_file = examples_dir / 'baseline_metrics.json'
     data = {}
     if out_file.exists():
         with open(out_file, 'r', encoding='utf-8') as f:

--- a/tools/divergence_heatmap.py
+++ b/tools/divergence_heatmap.py
@@ -12,7 +12,7 @@ extension) is used as the instance label.
 
 The script computes the average cosine distance between interpretations of each
 pair of instances using ``sentence-transformers``. Results are printed as a
-matrix, visualized as a heatmap, and logged to ``tools/divergence_log.json`` for
+matrix, visualized as a heatmap, and logged to ``docs/examples/divergence_log.json`` for
 further analysis.
 """
 
@@ -102,7 +102,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Generate cross-instance divergence heatmap")
     parser.add_argument("files", nargs="+", help="JSON interpretation files")
     parser.add_argument("--model", default="all-MiniLM-L6-v2", help="SentenceTransformer model")
-    parser.add_argument("--log", default="tools/divergence_log.json", help="Path to divergence log")
+    parser.add_argument("--log", default="docs/examples/divergence_log.json", help="Path to divergence log")
     parser.add_argument("--no-plot", action="store_true", help="Skip heatmap display")
     args = parser.parse_args()
 

--- a/tools/drift_monitor.py
+++ b/tools/drift_monitor.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Dict
 
-DRIFT_LOG = Path("tools/drift_tracker_log.json")
+DRIFT_LOG = Path("docs/examples/drift_tracker_log.json")
 
 
 def latest_metrics() -> Dict[str, float]:

--- a/tools/emergence_tracker.py
+++ b/tools/emergence_tracker.py
@@ -14,7 +14,7 @@ instance label.
 The script detects new interpretive clusters that do not appear in the
 baseline library, using sentence embeddings and agglomerative clustering.
 Metaphors with divergent yet convergent interpretations across instances
-are logged to ``tools/emergence_log.json`` with semantic distance metrics.
+are logged to ``docs/examples/emergence_log.json`` with semantic distance metrics.
 Optionally a heatmap visualises emergent interpretive intersections.
 """
 
@@ -182,7 +182,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Track emergent interpretive signals")
     parser.add_argument("files", nargs="+", help="Instance interpretation logs")
     parser.add_argument("--baseline", help="Baseline library JSON")
-    parser.add_argument("--output", default="tools/emergence_log.json", help="Output log path")
+    parser.add_argument("--output", default="docs/examples/emergence_log.json", help="Output log path")
     parser.add_argument("--model", default="all-MiniLM-L6-v2", help="SentenceTransformer model")
     parser.add_argument("--plot", action="store_true", help="Display heatmap summary")
     args = parser.parse_args()

--- a/tools/metrics_drift_tracker.py
+++ b/tools/metrics_drift_tracker.py
@@ -5,7 +5,7 @@
 Usage:
   python tools/metrics_drift_tracker.py [--log PATH] [--output PATH] [--plot]
 
-This script reads a monitoring log (default: tools/monitor_log.json) containing
+This script reads a monitoring log (default: docs/examples/monitor_log.json) containing
 timestamped live metrics:
  - interpretive_bandwidth
  - symbolic_density
@@ -14,7 +14,7 @@ timestamped live metrics:
 It performs sliding window analysis over 7-day and 30-day intervals to detect
 changes in interpretive flexibility. A "Flexibility Pulse" score represents the
 short-term trend relative to the longer baseline. Results are saved to
-``tools/drift_tracker_log.json`` and an optional plot may be displayed. Each
+``docs/examples/drift_tracker_log.json`` and an optional plot may be displayed. Each
 entry records the 7- and 30-day rolling averages for all metrics and the
 resulting ``flexibility_pulse``.
 
@@ -106,9 +106,9 @@ def plot_pulse(results):
 
 def main():
   parser = argparse.ArgumentParser(description="Temporal Drift Tracker")
-  parser.add_argument("--log", default="tools/monitor_log.json",
+  parser.add_argument("--log", default="docs/examples/monitor_log.json",
                       help="Path to monitor_log.json")
-  parser.add_argument("--output", default="tools/drift_tracker_log.json",
+  parser.add_argument("--output", default="docs/examples/drift_tracker_log.json",
                       help="Where to store drift analysis")
   parser.add_argument("--plot", action="store_true",
                       help="Display a matplotlib plot of the pulse")

--- a/tools/metrics_monitor.py
+++ b/tools/metrics_monitor.py
@@ -10,8 +10,9 @@ from typing import Dict
 
 from .instance_diff_engine import similarity_score
 
-BASE_DIR = Path(__file__).resolve().parent
-BASELINE_FILE = BASE_DIR / "baseline_metrics.json"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = REPO_ROOT / "docs" / "examples"
+BASELINE_FILE = EXAMPLES_DIR / "baseline_metrics.json"
 
 # Default interval for periodic checks (in minutes)
 DEFAULT_INTERVAL = timedelta(minutes=30)

--- a/tools/monitor_dkae.py
+++ b/tools/monitor_dkae.py
@@ -10,7 +10,7 @@ from sklearn.cluster import AgglomerativeClustering
 
 BASE_DIR = Path('metaphor-library/DKA-E')
 BASELINE_FILE = Path('tools/monitor_baseline.json')
-LOG_FILE = Path('tools/monitor_log.json')
+LOG_FILE = Path('docs/examples/monitor_log.json')
 PAIRED_DIR = Path('paired-outputs')
 MODEL_NAME = 'all-MiniLM-L6-v2'
 

--- a/tools/wonder_index_calculator.py
+++ b/tools/wonder_index_calculator.py
@@ -157,10 +157,10 @@ def plot_index(results: List[dict]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Compute Wonder Index")
-    parser.add_argument("--drift", default="tools/drift_tracker_log.json")
-    parser.add_argument("--div", default="tools/divergence_log.json")
-    parser.add_argument("--signals", default="tools/wonder_signals.json")
-    parser.add_argument("--output", default="tools/wonder_index_log.json")
+    parser.add_argument("--drift", default="docs/examples/drift_tracker_log.json")
+    parser.add_argument("--div", default="docs/examples/divergence_log.json")
+    parser.add_argument("--signals", default="docs/examples/wonder_signals.json")
+    parser.add_argument("--output", default="docs/examples/wonder_index_log.json")
     parser.add_argument("--plot", action="store_true")
     args = parser.parse_args()
 

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -27,7 +27,8 @@ except Exception:  # pragma: no cover - altair may not be installed
 from tools.realignment_trigger import DRIFT_THRESHOLDS, should_realign
 
 
-BASE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASE_DIR = REPO_ROOT / "docs" / "examples"
 BASELINE_FILE = BASE_DIR / "baseline_metrics.json"
 LOG_FILE = BASE_DIR / "monitor_log.json"
 DRIFT_FILE = BASE_DIR / "drift_tracker_log.json"


### PR DESCRIPTION
## Summary
- keep all logs in `docs/examples/`
- update monitoring tools for the new path
- revise dashboard usage docs
- ignore only log files in `docs/examples`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850ba043d1c832da73b04949e1f99df