### PR TITLE
Wire web test page to T‑BEEP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ python api/tbeep_api.py
 Messages can then be POSTed to `/api/v1/messages` and fetched by thread ID via
 `GET /api/v1/messages?thread_id=`.
 
+### Web Testing Interface
+
+The simple page at `ui/testing_interface/testing_framework.html` posts a
+T‑BEEP message to the running API when you click **Submit for Interpretation**.
+Open the file in your browser after starting the API to send a test message.
+
 ### Metaphor Library Extension
 
 The **DKA-E metaphors**—focusing on persistent knowledge structures, dynamic evolution, and collaborative orchestration—are now housed within the [**Metaphor Library**](./metaphor-library/DKA-E/). These extend the core DKA module, offering symbolic depth for advanced use cases.

--- a/ui/testing_interface/testing_framework.html
+++ b/ui/testing_interface/testing_framework.html
@@ -70,8 +70,39 @@ The lighthouse that illuminates by casting deeper shadows
   <script>
     function submitParadox() {
       const input = document.getElementById("paradoxInput").value;
-      console.log("Submitted construct:", input);
-      document.getElementById("confirmation").style.display = "block";
+      const msg = {
+        threadToken: "#WEB_001.0",
+        instance: "WebClient",
+        reasoningLevel: "Quick",
+        confidence: "Medium",
+        collaborationMode: "Testing",
+        timestamp: new Date().toISOString(),
+        version: "#WEB_001.v1.0",
+        content: input
+      };
+
+      fetch("/api/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(msg)
+      })
+      .then(res => {
+        if (res.ok) {
+          document.getElementById("confirmation").textContent =
+            "✅ Submitted to Codex. Awaiting interpretive divergence...";
+        } else {
+          document.getElementById("confirmation").textContent =
+            "❌ Error submitting message.";
+        }
+        document.getElementById("confirmation").style.display = "block";
+      })
+      .catch(() => {
+        document.getElementById("confirmation").textContent =
+          "❌ Network error.";
+        document.getElementById("confirmation").style.display = "block";
+      });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- connect `testing_framework.html` to the `/api/v1/messages` endpoint
- mention the web testing interface in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c42520b0832d99afd81095515e41