### PR TITLE
Fix realignment import and rounding

### DIFF
--- a/cpas_autogen/metrics_monitor.py
+++ b/cpas_autogen/metrics_monitor.py
@@ -41,7 +41,7 @@ def diff_report(current: Dict[str, float]) -> Dict[str, Dict[str, float]]:
         report[key] = {
             "baseline": base_val,
             "current": cur_val,
-            "delta": cur_val - base_val,
+            "delta": round(cur_val - base_val, 3),
         }
     report["similarity"] = similarity_score(
         {k: round(v, 3) for k, v in baseline.items()},

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -24,7 +24,7 @@ try:  # optional for nicer event plots
 except Exception:  # pragma: no cover - altair may not be installed
     alt = None
 
-from tools.realignment_trigger import DRIFT_THRESHOLDS, should_realign
+from cpas_autogen.realignment_trigger import DRIFT_THRESHOLDS, should_realign
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- import DRIFT_THRESHOLDS and should_realign from `cpas_autogen.realignment_trigger`
- round metrics monitor deltas to avoid float precision issues

## Testing
- `streamlit run ui/dashboard.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d204c71c832daf3e78aa10e42b28