### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ A modular standard for layered AI interaction, cross-instance collaboration, and
 - [**Research & Reflections**](./docs/research/)
 - [**Documentation Index**](docs/index.md)
 
+## Setup
+
+Run the helper script to install all Python dependencies:
+
+```bash
+./scripts/setup_env.sh
+```
+
+Packages like `torch` and `spacy` can take several minutes to download and
+install, so plan accordingly on first run.
+
 ## Installation
 
 Install the core dependencies with:

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Simple environment setup script
+# Installs Python dependencies listed in requirements.txt
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+pip install -r "$REPO_ROOT/requirements.txt"


### PR DESCRIPTION
## Summary
- add helper script to install requirements
- document setup instructions for new contributors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen')*

------
https://chatgpt.com/codex/tasks/task_e_6850d4159970832d9e93c9500273ca24