### PR TITLE
Fix dashboard realignment import

### DIFF
--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -24,7 +24,10 @@ try:  # optional for nicer event plots
 except Exception:  # pragma: no cover - altair may not be installed
     alt = None
 
-from tools.realignment_trigger import DRIFT_THRESHOLDS, should_realign
+from cpas_autogen.realignment_trigger import (
+    DRIFT_THRESHOLDS,
+    should_realign,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- update dashboard to import realignment helpers from `cpas_autogen`

## Testing
- `python -m ui.dashboard` *(fails: Unknown datetime string format)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851774a3334832dba97ed4e5962519b