### PR TITLE
Document optional dashboard and API install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A modular standard for layered AI interaction, cross-instance collaboration, and
 ```bash
 git clone <repo-url> && cd Reflective-AI-and-CPAS-Core
 pip install -r requirements.txt
-pip install -e .
+pip install -e ".[web]"
 python tools/generate_autogen_agents.py
 streamlit run ui/dashboard.py &
 flask run --app api/tbeep_api.py
@@ -52,11 +52,18 @@ Install the core dependencies with:
 
 ```bash
 pip install -r requirements.txt
+pip install -e .
+```
+
+Install optional dashboard and API features with:
+
+```bash
+pip install -e ".[web]"
 ```
 
 ### Drift Monitoring Dashboard
 
-Visualize the flexibility pulse by running:
+Visualize the flexibility pulse (requires the `web` extras) by running:
 
 ```bash
 streamlit run ui/dashboard.py
@@ -68,8 +75,8 @@ summarizing baseline drift and the wonder index across all active instances.
 ### T-BEEP API Example
 
 An experimental Flask service in `api/tbeep_api.py` accepts and stores T-BEEP
-messages in memory only. Persistent storage and authentication are pending.
-Start the API with:
+messages in memory only. Persistent storage and authentication are pending. This
+feature also requires the `web` extras. Start the API with:
 
 ```bash
 python api/tbeep_api.py

--- a/docs/alpha_milestone.md
+++ b/docs/alpha_milestone.md
@@ -6,6 +6,7 @@ This alpha release bundles core CPAS monitoring with AutoGen-compatible agents.
 - EpistemicAgentMixin and reusable utilities in `cpas_autogen`
 - Streamlit dashboard for drift metrics and Wonder Index
 - In-memory Flask API implementing T-BEEP messaging
+- (requires installing the `web` extras)
 - Agent generation script producing AutoGen wrappers
 
 ## Not Included

--- a/docs/dashboard_usage.md
+++ b/docs/dashboard_usage.md
@@ -1,6 +1,7 @@
 # Dynamic Dashboard Prototype
 
 `ui/dashboard.py` provides a lightweight Streamlit interface for real-time visualization of epistemic metrics. The dashboard now consolidates multiple views including Flexibility Pulse, Wonder Index trends, emergence events and realignment indicators.
+Install the `web` extras to enable this optional component.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ setup(
     packages=find_packages(include=["cpas_autogen", "cpas_autogen.*"]),
     description="CPAS AutoGen utilities",
     install_requires=[
-        "Flask",
-        "streamlit",
         "pandas",
         "matplotlib",
         "sentence-transformers",
@@ -18,4 +16,7 @@ setup(
         "requests",
         "jsonschema",
     ],
+    extras_require={
+        "web": ["Flask", "streamlit"],
+    },
 )


### PR DESCRIPTION
## Summary
- add `web` optional extras in setup.py
- document extras in README quickstart and installation notes
- mention optional web extras in dashboard docs
- note extras in alpha milestone scope

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685187397290832db4f1025a19127bbc