### PR TITLE
Fix timestamp parsing and update Flask run docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ pip install -r requirements.txt
 pip install -e ".[web]"
 python tools/generate_autogen_agents.py
 streamlit run ui/dashboard.py
-flask run --app api/tbeep_api.py
+# For Flask >=2.2 you can use ``--app``; older versions require setting
+# the ``FLASK_APP`` environment variable first. On PowerShell:
+#     $env:FLASK_APP = "api/tbeep_api.py"
+# then run:
+flask run
 ```
 
 ## Installation
@@ -80,7 +84,11 @@ messages in memory only. Persistent storage and authentication are pending. This
 feature also requires the `web` extras. Start the API with:
 
 ```bash
+# Either run the module directly
 python api/tbeep_api.py
+# or, with Flask's CLI (PowerShell syntax shown):
+# $env:FLASK_APP = "api/tbeep_api.py"
+# flask run
 ```
 
 Messages can then be POSTed to `/api/v1/messages` and fetched by thread ID via `GET /api/v1/messages?thread_id=`.

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -162,9 +162,14 @@ emergence_data = load_json(EMERGENCE_FILE)
 drift_data = load_json(DRIFT_FILE)
 
 baseline_metrics = latest_entry(baseline_data)
-log_df = pd.DataFrame(log_data).T
-if not log_df.empty:
-    log_df.index = pd.to_datetime(log_df.index)
+# ``log_data`` is a list of dicts with a ``timestamp`` field. Creating
+# the DataFrame with default orientation keeps each log entry as a row
+# which allows proper datetime parsing.
+log_df = pd.DataFrame(log_data)
+if not log_df.empty and "timestamp" in log_df.columns:
+    # parse and index by timestamp so time-based sorting works
+    log_df["timestamp"] = pd.to_datetime(log_df["timestamp"])
+    log_df.set_index("timestamp", inplace=True)
     log_df.sort_index(inplace=True)
     current_metrics = log_df.iloc[-1].to_dict()
 else:


### PR DESCRIPTION
## Summary
- fix creation of log dataframe so timestamp parsing works
- clarify how to run the Flask API in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e218bfc8832d8dc4f69d3988a0fc