### PR TITLE
Add metric validation stats

### DIFF
--- a/docs/research/metric_validation.md
+++ b/docs/research/metric_validation.md
@@ -1,0 +1,13 @@
+# Metric Validation Methods
+
+This document summarizes how lexical diversity, symbolic density, and divergence space metrics are validated in CPAS-Core.
+
+## Sample Size
+The validation suite uses 13 metaphor entries drawn from the DKA-E library along with README and index text. Random subsets of these texts are sampled during each iteration.
+
+## Statistical Methods
+- **Correlation tests:** Pearson correlation coefficients are computed across five random subsets to examine interdependence of metrics.
+- **Reliability:** Split-half reliability is estimated by shuffling texts and comparing metric scores between halves.
+
+## Significance Thresholds
+Correlations exceeding |0.5| are considered notable. Reliability scores above 0.7 indicate acceptable stability.

--- a/tests/test_metric_validation.py
+++ b/tests/test_metric_validation.py
@@ -1,0 +1,22 @@
+import pytest
+pytest.importorskip("spacy")
+
+import spacy
+from tools import baseline_metrics as bm
+
+nlp = spacy.blank("en")
+
+TEXTS = [
+    "alpha beta gamma",
+    "delta epsilon zeta",
+    "eta theta iota",
+    "kappa lambda mu",
+    "nu xi omicron",
+]
+
+
+def test_reliability_scores():
+    stats = bm.metric_correlations(TEXTS, nlp, iterations=3)
+    assert all(-1.0 <= v <= 1.0 for v in stats.values())
+    reli = bm.reliability_score(bm.lexical_diversity, TEXTS, nlp, iterations=3)
+    assert -1.0 <= reli <= 1.0


### PR DESCRIPTION
## Summary
- implement reliability and correlation helpers in `baseline_metrics.py`
- output validation statistics alongside metrics
- document sample size and statistical approach
- test metric validation utilities

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68531cbc29dc832dbdb82c69deb5775e