### PR TITLE
Add simple benchmarking suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,16 @@
+# Benchmark Suite
+
+This directory contains simple benchmark scripts for CPAS-Core.
+
+- `hardware_specs.py` records hardware and environment information.
+- `token_processing.py` measures token processing speed using spaCy.
+- `update_throughput.py` measures how quickly the T-BEEP API can store messages.
+- `run_all.py` executes all benchmarks in sequence and appends results to `results.log`.
+
+Run the suite with:
+
+```bash
+python benchmarks/run_all.py
+```
+
+Results are appended to `results.log` in JSON-lines format.

--- a/benchmarks/hardware_specs.py
+++ b/benchmarks/hardware_specs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Collect basic hardware specs and environment configuration."""
+
+import json
+import platform
+from pathlib import Path
+
+try:
+    import psutil
+except Exception:
+    psutil = None
+
+
+def gather_specs() -> dict[str, str | float | int]:
+    info = {
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+    }
+    if psutil:
+        info.update({
+            "cpu_count": psutil.cpu_count(logical=True),
+            "memory_gb": round(psutil.virtual_memory().total / (1024 ** 3), 2),
+        })
+    return info
+
+
+def main() -> None:
+    specs = gather_specs()
+    out = Path(__file__).with_name('results.log')
+    with out.open('a', encoding='utf-8') as f:
+        f.write(json.dumps({"hardware_specs": specs}) + '\n')
+    print(specs)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/results.log
+++ b/benchmarks/results.log
@@ -1,0 +1,5 @@
+{"hardware_specs": {"python_version": "3.12.10", "platform": "Linux-6.12.13-x86_64-with-glibc2.39", "processor": "x86_64"}}
+{"hardware_specs": {"python_version": "3.12.10", "platform": "Linux-6.12.13-x86_64-with-glibc2.39", "processor": "x86_64"}}
+{"hardware_specs": {"python_version": "3.12.10", "platform": "Linux-6.12.13-x86_64-with-glibc2.39", "processor": "x86_64"}}
+{"token_processing": {"tokens": 1462, "seconds": 0.013857268999970529, "tokens_per_second": 105504.19422493056}}
+{"update_throughput": {"updates": 100, "seconds": 0.0601910240000052, "updates_per_second": 1661.37728442685}}

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Run all benchmark scripts and log results."""
+
+import subprocess
+from pathlib import Path
+
+SCRIPTS = [
+    'hardware_specs.py',
+    'token_processing.py',
+    'update_throughput.py',
+]
+
+
+def main() -> None:
+    bench_dir = Path(__file__).resolve().parent
+    for name in SCRIPTS:
+        subprocess.run(['python', str(bench_dir / name)], check=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/token_processing.py
+++ b/benchmarks/token_processing.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Benchmark script for measuring token processing speed."""
+
+import time
+import json
+from pathlib import Path
+import spacy
+
+
+def load_texts(base: Path) -> list[str]:
+    texts: list[str] = []
+    for path in base.rglob('*.md'):
+        texts.append(path.read_text(encoding='utf-8'))
+    return texts
+
+
+def benchmark(nlp, texts: list[str]) -> dict[str, float]:
+    """Return tokens per second for processing ``texts``."""
+    start = time.perf_counter()
+    tokens = 0
+    for doc in nlp.pipe(texts):
+        tokens += len(doc)
+    elapsed = time.perf_counter() - start
+    tps = tokens / elapsed if elapsed else 0.0
+    return {"tokens": tokens, "seconds": elapsed, "tokens_per_second": tps}
+
+
+def main() -> None:
+    base = Path(__file__).resolve().parents[1] / 'metaphor-library'
+    texts = load_texts(base)
+    try:
+        nlp = spacy.load('en_core_web_sm')
+    except Exception:
+        nlp = spacy.blank('en')
+    result = benchmark(nlp, texts)
+    out = Path(__file__).with_name('results.log')
+    with out.open('a', encoding='utf-8') as f:
+        f.write(json.dumps({"token_processing": result}) + '\n')
+    print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/update_throughput.py
+++ b/benchmarks/update_throughput.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Benchmark script for measuring update throughput of the T-BEEP API."""
+
+import json
+import time
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from api.tbeep_api import app
+
+
+def benchmark(count: int = 100) -> dict[str, float]:
+    client = app.test_client()
+    payload = {
+        "threadToken": "#BENCH_001.0",
+        "instance": "Bench",
+        "reasoningLevel": "Basic",
+        "confidence": "High",
+        "collaborationMode": "Benchmark",
+        "timestamp": "2025-01-01T00:00:00Z",
+        "version": "#BENCH.v1.0",
+        "content": "x",
+    }
+    start = time.perf_counter()
+    for _ in range(count):
+        client.post("/api/v1/messages", json=payload)
+    elapsed = time.perf_counter() - start
+    ups = count / elapsed if elapsed else 0.0
+    return {"updates": count, "seconds": elapsed, "updates_per_second": ups}
+
+
+def main() -> None:
+    result = benchmark()
+    out = Path(__file__).with_name('results.log')
+    with out.open('a', encoding='utf-8') as f:
+        f.write(json.dumps({"update_throughput": result}) + '\n')
+    print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/specs/current/CPAS-Core-v1.1.md
+++ b/docs/specs/current/CPAS-Core-v1.1.md
@@ -146,6 +146,8 @@ Partnership Evolution: "Iterative refinement — resonance alignment"
 
 * Confidence calibration and coherence checks.
 * Performance and memory benchmarks.
+* Benchmark logs for token processing and update throughput recorded in
+  `benchmarks/results.log` along with hardware specifications.
 * Collaborative effectiveness and user satisfaction.
 
 ### Recovery & Degradation


### PR DESCRIPTION
## Summary
- create new `benchmarks/` directory
- add token processing and update throughput benchmarks
- capture hardware specs and log results
- link benchmark logs from spec

## Testing
- `pytest -q`
- `python benchmarks/token_processing.py`
- `python benchmarks/update_throughput.py`


------
https://chatgpt.com/codex/tasks/task_e_68531fa79e0c832d96a54980d19e3ae0