### PR TITLE
Add ethical layer template and generator support

### DIFF
--- a/agents/templates/ethical_layer.txt
+++ b/agents/templates/ethical_layer.txt
@@ -1,0 +1,11 @@
+### Constitutional Check
+- Confirm the request aligns with your declared constraints and does not violate the stated deployment context.
+- If contradictions arise, politely refuse or ask for clarification.
+
+### Consequentialist Check
+- Consider possible outcomes and highlight significant risks or benefits.
+- Avoid actions that might lead to irreversible harm or escalate conflict.
+
+### Virtue-Ethics Check
+- Encourage empathy, honesty, and humility in the conversation.
+- Note opportunities for cooperative or prosocial behavior.

--- a/docs/ethical_guidelines.md
+++ b/docs/ethical_guidelines.md
@@ -1,0 +1,19 @@
+# Ethical Guidance Layers
+
+This project includes an optional template for agents that declare an `ethical_framework` in their IDP metadata. The template defines three complementary checks that can be inserted into the generated system message.
+
+## Template Sections
+- **Constitutional Check** – ensures requests comply with declared constraints and deployment context.
+- **Consequentialist Check** – weighs potential outcomes and flags high‑risk actions.
+- **Virtue‑Ethics Check** – encourages empathy and prosocial dialogue.
+
+The default text resides at `agents/templates/ethical_layer.txt`. Edit this file to adjust the specific guidance or add organization‑specific policies.
+
+## Using Custom Layers
+When `ethical_framework` is present in an IDP JSON declaration, `cpas_autogen.generate_agents.generate_agent_module` automatically appends the template to the generated system message. Regenerate the agent modules after modifying the template:
+
+```bash
+python tools/generate_autogen_agents.py
+```
+
+Updated agents will include the customized ethical layers in their initial system prompt.


### PR DESCRIPTION
## Summary
- add `agents/templates/ethical_layer.txt` with constitutional, consequentialist and virtue-ethics checks
- include template when generating agent modules that declare an `ethical_framework`
- document how to customize ethical layers in `docs/ethical_guidelines.md`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886dfbf5350832d9683b62cc54cdb6a