### PR TITLE
Add drift utilities and metrics updater

### DIFF
--- a/cpas_autogen/drift_monitor.py
+++ b/cpas_autogen/drift_monitor.py
@@ -6,16 +6,14 @@ import json
 from pathlib import Path
 from typing import Dict
 
+from datetime import datetime, timedelta
+
 from .config import DRIFT_LOG
 
 
-def latest_metrics() -> Dict[str, float]:
-    """Return the most recent drift metrics from ``DRIFT_LOG``.
+def latest_averages() -> Dict[str, Dict[str, float]]:
+    """Return the most recent 7- and 30-day averages from ``DRIFT_LOG``."""
 
-    The metrics are extracted from the 7-day rolling averages in
-    ``drift_tracker_log.json``. If the log is missing or malformed,
-    an empty dictionary is returned.
-    """
     if not DRIFT_LOG.exists():
         return {}
     try:
@@ -24,13 +22,36 @@ def latest_metrics() -> Dict[str, float]:
         return {}
     if isinstance(data, list) and data:
         last = data[-1]
-        avg = last.get("avg_7_day", {})
+        avg7 = last.get("avg_7_day", {})
+        avg30 = last.get("avg_30_day", {})
         return {
-            "interpretive_bandwidth": float(avg.get("interpretive_bandwidth", 0)),
-            "symbolic_density": float(avg.get("symbolic_density", 0)),
-            "divergence_score": float(avg.get("divergence_space", 0)),
+            "avg_7_day": {
+                "interpretive_bandwidth": float(avg7.get("interpretive_bandwidth", 0)),
+                "symbolic_density": float(avg7.get("symbolic_density", 0)),
+                "divergence_space": float(avg7.get("divergence_space", 0)),
+            },
+            "avg_30_day": {
+                "interpretive_bandwidth": float(avg30.get("interpretive_bandwidth", 0)),
+                "symbolic_density": float(avg30.get("symbolic_density", 0)),
+                "divergence_space": float(avg30.get("divergence_space", 0)),
+            },
+            "flexibility_pulse": float(last.get("flexibility_pulse", 0)),
         }
     return {}
 
 
-__all__ = ["latest_metrics"]
+def latest_metrics() -> Dict[str, float]:
+    """Return the most recent 7-day drift metrics."""
+
+    avgs = latest_averages()
+    if not avgs:
+        return {}
+    avg = avgs.get("avg_7_day", {})
+    return {
+        "interpretive_bandwidth": float(avg.get("interpretive_bandwidth", 0)),
+        "symbolic_density": float(avg.get("symbolic_density", 0)),
+        "divergence_score": float(avg.get("divergence_space", 0)),
+    }
+
+
+__all__ = ["latest_metrics", "latest_averages"]

--- a/docs/update_metrics_usage.md
+++ b/docs/update_metrics_usage.md
@@ -1,0 +1,19 @@
+# Metrics Update Utility
+
+`tools/update_metrics.py` appends session metrics to the monitoring logs and refreshes baseline values.
+
+## Manual Usage
+
+```bash
+python tools/update_metrics.py path/to/session_metrics.json
+```
+
+`session_metrics.json` must provide `interpretive_bandwidth`, `symbolic_density` and `divergence_space` values.
+
+## Cron Example
+
+To run the update every day at 2am:
+
+```
+0 2 * * * /usr/bin/python /path/to/tools/update_metrics.py /path/to/session_metrics.json
+```

--- a/tests/test_drift_monitor.py
+++ b/tests/test_drift_monitor.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+from cpas_autogen import drift_monitor
+
+
+def test_latest_averages(tmp_path, monkeypatch):
+    log = [
+        {
+            "timestamp": "2025-01-01T00:00:00",
+            "avg_7_day": {
+                "interpretive_bandwidth": 0.5,
+                "symbolic_density": 0.6,
+                "divergence_space": 0.7,
+            },
+            "avg_30_day": {
+                "interpretive_bandwidth": 0.4,
+                "symbolic_density": 0.5,
+                "divergence_space": 0.6,
+            },
+            "flexibility_pulse": 0.1,
+        },
+        {
+            "timestamp": "2025-01-02T00:00:00",
+            "avg_7_day": {
+                "interpretive_bandwidth": 0.55,
+                "symbolic_density": 0.65,
+                "divergence_space": 0.75,
+            },
+            "avg_30_day": {
+                "interpretive_bandwidth": 0.45,
+                "symbolic_density": 0.55,
+                "divergence_space": 0.65,
+            },
+            "flexibility_pulse": 0.2,
+        },
+    ]
+    file = tmp_path / "drift.json"
+    file.write_text(json.dumps(log))
+    monkeypatch.setattr(drift_monitor, "DRIFT_LOG", file)
+
+    avgs = drift_monitor.latest_averages()
+    assert avgs["avg_7_day"]["interpretive_bandwidth"] == 0.55
+    assert avgs["avg_30_day"]["divergence_space"] == 0.65
+    assert avgs["flexibility_pulse"] == 0.2
+
+    metrics = drift_monitor.latest_metrics()
+    assert metrics["interpretive_bandwidth"] == 0.55
+    assert metrics["symbolic_density"] == 0.65
+    assert metrics["divergence_score"] == 0.75

--- a/tools/update_metrics.py
+++ b/tools/update_metrics.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Append session metrics to monitoring logs.
+
+Usage:
+  python tools/update_metrics.py SESSION_METRICS.json
+
+SESSION_METRICS.json should contain keys ``interpretive_bandwidth``,
+``symbolic_density`` and ``divergence_space``. The script appends the
+metrics to ``docs/examples/monitor_log.json`` and updates
+drift metrics in ``docs/examples/drift_tracker_log.json``. Baseline
+values are refreshed via ``tools/update_baselines.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from cpas_autogen.config import MONITOR_LOG, DRIFT_LOG
+from tools.metrics_drift_tracker import load_log, analyze
+from tools.update_baselines import main as update_baselines_main
+
+
+MetricDict = Dict[str, float]
+
+
+def load_metrics(path: Path) -> MetricDict:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return {
+        "interpretive_bandwidth": float(data.get("interpretive_bandwidth", 0)),
+        "symbolic_density": float(data.get("symbolic_density", 0)),
+        "divergence_space": float(data.get("divergence_space", 0)),
+    }
+
+
+def append_monitor(entry: Dict[str, float]) -> None:
+    log: List[dict] = []
+    if MONITOR_LOG.exists():
+        try:
+            log = json.loads(MONITOR_LOG.read_text())
+            if not isinstance(log, list):
+                log = []
+        except Exception:
+            log = []
+    log.append(entry)
+    MONITOR_LOG.write_text(json.dumps(log, indent=2))
+
+
+def append_drift() -> None:
+    entries = load_log(MONITOR_LOG)
+    results = analyze(entries)
+    if not results:
+        return
+    last = results[-1]
+    drift_entry = {
+        "timestamp": last["timestamp"],
+        "avg_7_day": {
+            "interpretive_bandwidth": last["interpretive_bandwidth_7d"],
+            "symbolic_density": last["symbolic_density_7d"],
+            "divergence_space": last["divergence_space_7d"],
+        },
+        "avg_30_day": {
+            "interpretive_bandwidth": last["interpretive_bandwidth_30d"],
+            "symbolic_density": last["symbolic_density_30d"],
+            "divergence_space": last["divergence_space_30d"],
+        },
+        "flexibility_pulse": last["flexibility_pulse"],
+    }
+    data: List[dict] = []
+    if DRIFT_LOG.exists():
+        try:
+            data = json.loads(DRIFT_LOG.read_text())
+            if not isinstance(data, list):
+                data = []
+        except Exception:
+            data = []
+    data.append(drift_entry)
+    DRIFT_LOG.write_text(json.dumps(data, indent=2))
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Update monitoring logs")
+    parser.add_argument("metrics", help="Path to session metrics JSON file")
+    args = parser.parse_args(argv)
+
+    metrics = load_metrics(Path(args.metrics))
+    entry = {"timestamp": datetime.utcnow().isoformat(), **metrics}
+    append_monitor(entry)
+    append_drift()
+
+    try:
+        update_baselines_main()
+    except Exception as exc:
+        print(f"Failed to update baselines: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/update_metrics.py` for logging session metrics
- document usage and cron setup
- extend `drift_monitor` with `latest_averages`
- add unit tests for drift monitor averages

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688821a7db54832d8793a6a77bbaae8c