### PR TITLE
Add drift threshold config file

### DIFF
--- a/cpas_autogen/realignment_trigger.py
+++ b/cpas_autogen/realignment_trigger.py
@@ -2,15 +2,30 @@ from __future__ import annotations
 
 """Realignment trigger utility."""
 
+import json
 import logging
+from pathlib import Path
 from typing import Dict, Any
 
-# Thresholds for drift metrics that require realignment
-DRIFT_THRESHOLDS: Dict[str, float] = {
+# Threshold configuration
+THRESHOLDS_FILE = Path(__file__).with_name("thresholds.json")
+_DEFAULT_THRESHOLDS: Dict[str, float] = {
     "symbolic_density": 0.4,
     "interpretive_bandwidth": 0.6,
     "divergence_score": 0.5,
 }
+
+# Thresholds for drift metrics that require realignment
+DRIFT_THRESHOLDS: Dict[str, float] = dict(_DEFAULT_THRESHOLDS)
+if THRESHOLDS_FILE.exists():
+    try:
+        data = json.loads(THRESHOLDS_FILE.read_text())
+        if isinstance(data, dict):
+            for key in DRIFT_THRESHOLDS:
+                if key in data:
+                    DRIFT_THRESHOLDS[key] = float(data[key])
+    except Exception as exc:  # pragma: no cover - don't break on errors
+        logging.warning("Failed to load thresholds: %s", exc)
 
 
 def should_realign(drift_metrics: Dict[str, float], *, agent: Any | None = None,

--- a/cpas_autogen/thresholds.json
+++ b/cpas_autogen/thresholds.json
@@ -1,0 +1,5 @@
+{
+  "symbolic_density": 0.4,
+  "interpretive_bandwidth": 0.6,
+  "divergence_score": 0.5
+}

--- a/docs/monitor_dkae_usage.md
+++ b/docs/monitor_dkae_usage.md
@@ -27,3 +27,10 @@ chmod +x .git/hooks/post-commit
 ```
 
 The hook will revert the last commit automatically if a rollback trigger is activated.
+
+## Adjusting Thresholds
+
+`tools/monitor_dkae.py` and other utilities read drift thresholds from
+`cpas_autogen/thresholds.json`. Edit that file to change the values for
+`symbolic_density`, `interpretive_bandwidth`, or `divergence_score`. The new
+thresholds will be applied the next time the monitor runs.


### PR DESCRIPTION
## Summary
- add JSON thresholds file
- load thresholds dynamically in `realignment_trigger.py`
- document how to tweak thresholds in the monitoring guide

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68882aaa7820832da61d5ce4bcf99f9e