### PR TITLE
Add wonder and emergence visualizations

### DIFF
--- a/docs/dashboard_usage.md
+++ b/docs/dashboard_usage.md
@@ -11,5 +11,9 @@ streamlit run ui/dashboard.py
 
 The dashboard reads baseline values from `docs/examples/baseline_metrics.json` and live metrics from `docs/examples/monitor_log.json`.
 It also displays data from `docs/examples/drift_tracker_log.json`, `docs/examples/wonder_index_log.json` and `docs/examples/emergence_log.json`.
+Additional line charts visualize trends from these logs. Sample data files can be downloaded directly from the repository:
+
+- [docs/examples/wonder_index_log.json](../docs/examples/wonder_index_log.json)
+- [docs/examples/emergence_log.json](../docs/examples/emergence_log.json)
 Drift metrics are checked against realignment thresholds and highlighted when thresholds are exceeded. A collaborative **Wonder Signals** text area is available for qualitative notes.
 You can additionally upload a metrics log in JSON format via the sidebar for ad-hoc drift analysis.

--- a/docs/examples/emergence_log.json
+++ b/docs/examples/emergence_log.json
@@ -1,0 +1,18 @@
+[
+  {
+    "timestamp": "2024-06-12T12:00:00",
+    "metaphor": "ocean_car",
+    "instances": ["Lumin", "Telos"],
+    "description": "The car is an ocean of possibilities",
+    "divergence": 0.9,
+    "baseline_similarity": 0.2
+  },
+  {
+    "timestamp": "2024-06-17T12:00:00",
+    "metaphor": "sky_bird",
+    "instances": ["Clarence-9", "Meridian"],
+    "description": "Bird soared the sky of reason",
+    "divergence": 0.85,
+    "baseline_similarity": 0.15
+  }
+]

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -121,6 +121,43 @@ def show_charts(df: pd.DataFrame) -> None:
                 st.info(f"{metric} not found")
 
 
+def show_wonder_index(df: pd.DataFrame) -> None:
+    """Display Wonder Index and its components."""
+    st.header("Wonder Index Trend")
+    cols = [
+        c
+        for c in [
+            "interpretive_bandwidth_norm",
+            "symbolic_density_norm",
+            "divergence_norm",
+            "wonder_index",
+        ]
+        if c in df.columns
+    ]
+    if cols:
+        st.line_chart(df[cols], use_container_width=True)
+
+
+def show_emergence_timeline(df: pd.DataFrame) -> None:
+    """Visualize logged emergence clusters."""
+    st.header("Emergence Clusters")
+    if alt:
+        chart = (
+            alt.Chart(df)
+            .mark_circle(color="orange", size=80)
+            .encode(
+                x="timestamp:T",
+                y=alt.value(0),
+                tooltip=["timestamp:T", "description:N"],
+            )
+            .properties(height=120)
+        )
+        st.altair_chart(chart, use_container_width=True)
+    else:
+        st.scatter_chart(df.set_index("timestamp")[[]], use_container_width=True)
+    st.dataframe(df[["timestamp", "description"]])
+
+
 def suggest_realign(df: pd.DataFrame) -> None:
     if df.empty:
         return
@@ -283,28 +320,10 @@ with right:
         st.line_chart(pulse_df[["flexibility_pulse"]], use_container_width=True)
 
     if not wonder_df.empty:
-        st.header("Wonder Index")
-        st.line_chart(wonder_df[["wonder_index"]], use_container_width=True)
+        show_wonder_index(wonder_df)
 
     if not emergence_df.empty:
-        st.header("Emergence Clusters")
-        if alt:
-            chart = (
-                alt.Chart(emergence_df)
-                .mark_circle(color="orange", size=80)
-                .encode(
-                    x="timestamp:T",
-                    y=alt.value(0),
-                    tooltip=["timestamp:T", "description:N"],
-                )
-                .properties(height=120)
-            )
-            st.altair_chart(chart, use_container_width=True)
-        else:
-            st.scatter_chart(
-                emergence_df.set_index("timestamp")[[]], use_container_width=True
-            )
-        st.dataframe(emergence_df[["timestamp", "description"]])
+        show_emergence_timeline(emergence_df)
 
     if not daily_log.empty or not daily_drift.empty:
         st.header("Daily Digest")


### PR DESCRIPTION
## Summary
- visualize Wonder Index values and emergence clusters in `dashboard.py`
- document how to grab example logs
- include an example `emergence_log.json`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68882ee74838832d8e64aa250481163c