### PR TITLE
Improve monitoring documentation

### DIFF
--- a/docs/dashboard_usage.md
+++ b/docs/dashboard_usage.md
@@ -11,7 +11,9 @@ streamlit run ui/dashboard.py
 
 The dashboard reads baseline values from `docs/examples/baseline_metrics.json` and live metrics from `docs/examples/monitor_log.json`.
 It also displays data from `docs/examples/drift_tracker_log.json`, `docs/examples/wonder_index_log.json` and `docs/examples/emergence_log.json`.
-Additional line charts visualize trends from these logs. Sample data files can be downloaded directly from the repository:
+Wonder Index values are plotted alongside their normalized components, while emergence clusters are shown on a timeline.
+A *Daily Digest* section summarizes the current day's monitor log and drift tracker entries, giving a quick snapshot of recent activity.
+Sample data files can be downloaded directly from the repository:
 
 - [docs/examples/wonder_index_log.json](../docs/examples/wonder_index_log.json)
 - [docs/examples/emergence_log.json](../docs/examples/emergence_log.json)

--- a/docs/monitor_dkae_usage.md
+++ b/docs/monitor_dkae_usage.md
@@ -34,3 +34,14 @@ The hook will revert the last commit automatically if a rollback trigger is acti
 `cpas_autogen/thresholds.json`. Edit that file to change the values for
 `symbolic_density`, `interpretive_bandwidth`, or `divergence_score`. The new
 thresholds will be applied the next time the monitor runs.
+## Digest Generation
+
+When a session ends or a major epistemic shift occurs, a digest of the current DKA state can be generated using `cpas_autogen.dka_persistence.generate_digest`. The resulting dictionary contains metadata such as `digest_id`, timestamps and the participating instances.
+
+## Storage Paths
+
+By default digests are stored under `docs/examples/dka_digests/` as JSON files. The exact location is defined by the `DIGEST_DIR` constant in `cpas_autogen/dka_persistence.py`. Each file name matches the `digest_id` with a `.json` extension and includes a `hash` field for integrity checking.
+
+## Retrieval
+
+Historical digests can be loaded with `cpas_autogen.dka_persistence.retrieve_digests`. Pass a context dictionary like `{"instances": ["Lumin"]}` to filter digests by participating instances. The function returns a list of digests sorted by creation time, newest first, which can then be rehydrated using `rehydrate_context`.

--- a/docs/update_metrics_usage.md
+++ b/docs/update_metrics_usage.md
@@ -17,3 +17,19 @@ To run the update every day at 2am:
 ```
 0 2 * * * /usr/bin/python /path/to/tools/update_metrics.py /path/to/session_metrics.json
 ```
+## Message Logger Example
+
+`cpas_autogen.message_logger.log_message` records each AI message to `examples/message_manifest.json`. It expects the conversation `threadToken`, UTC timestamp, instance name, seed token, message content hash and the fingerprint.
+
+```python
+from cpas_autogen.message_logger import log_message
+
+log_message(
+    thread_token="demo-thread-1",
+    timestamp="2025-06-10T12:00:00Z",
+    instance="Lumin",
+    seed_token="seed-001",
+    content_hash="d41d8cd98f00b204e9800998ecf8427e",
+    fingerprint="fp-0001",
+)
+```


### PR DESCRIPTION
## Summary
- document digest generation, storage path and retrieval
- explain dashboard features for Wonder Index, emergence data and daily digests
- show message logger usage

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688831b4e7a4832da2bf4bc07b34147e