### PR TITLE
Add metaphor metadata to digests

### DIFF
--- a/cpas_autogen/dka_persistence.py
+++ b/cpas_autogen/dka_persistence.py
@@ -35,6 +35,8 @@ def generate_digest(session_state: Dict) -> Dict:
         "temporal_metadata": session_state.get("temporal_metadata", {}),
         "inter_dka_linkages": session_state.get("inter_dka_linkages", []),
         "rehydration_instructions": session_state.get("rehydration_instructions", {}),
+        "metaphor_category": session_state.get("metaphor_category", ""),
+        "library_version": session_state.get("library_version", ""),
     }
     return digest
 
@@ -49,6 +51,8 @@ def store_digest(digest: Dict, path: Path = DIGEST_DIR) -> Path:
     """Store ``digest`` as JSON in ``path`` and return the file path."""
     path.mkdir(parents=True, exist_ok=True)
     digest_no_hash = dict(digest)
+    digest_no_hash.setdefault("metaphor_category", "")
+    digest_no_hash.setdefault("library_version", "")
     digest_hash = _compute_hash(digest_no_hash)
     digest_no_hash["hash"] = digest_hash
     file_path = path / f"{digest_no_hash['digest_id']}.json"

--- a/tests/test_dka_persistence.py
+++ b/tests/test_dka_persistence.py
@@ -4,21 +4,33 @@ from cpas_autogen import dka_persistence
 
 
 def test_generate_digest_keys():
-    state = {"participating_instances": ["A", "B"]}
+    state = {
+        "participating_instances": ["A", "B"],
+        "metaphor_category": "Navigation",
+        "library_version": "MLib-v0.1",
+    }
     digest = dka_persistence.generate_digest(state)
     assert digest["digest_version"] == "1.0"
     assert digest["participating_instances"] == ["A", "B"]
     assert digest["digest_id"].startswith("DKA_")
+    assert digest["metaphor_category"] == "Navigation"
+    assert digest["library_version"] == "MLib-v0.1"
 
 
 def test_store_digest_hash(tmp_path):
-    state = {"participating_instances": ["A"]}
+    state = {
+        "participating_instances": ["A"],
+        "metaphor_category": "Illumination",
+        "library_version": "MLib-v0.1",
+    }
     digest = dka_persistence.generate_digest(state)
     file_path = dka_persistence.store_digest(digest, path=tmp_path)
     data = json.loads(file_path.read_text())
     stored_hash = data.pop("hash")
     expected = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8")).hexdigest()
     assert stored_hash == expected
+    assert data["metaphor_category"] == "Illumination"
+    assert data["library_version"] == "MLib-v0.1"
 
 
 def test_retrieve_digests_filter(tmp_path):


### PR DESCRIPTION
## Summary
- track metaphor library metadata in digests
- store default metadata fields when saving
- check new fields in digest tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688985231ec4832d9969c2920f035fe0