### PR TITLE
Update wonder signal logging to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ streamlit run ui/dashboard.py
 The dashboard now includes a scrolling message feed and a right-hand metrics panel
 summarizing baseline drift and the wonder index across all active instances.
 
+### Logging Wonder Signals
+
+Short reflective notes can be appended to `docs/examples/wonder_signals.json`
+using:
+
+```bash
+python tools/record_wonder.py "A brief insight"
+```
+
+Each invocation adds a timestamped JSON object of the form
+`{"timestamp": "...", "text": "..."}` which is later consumed by the Wonder
+Index calculator.
+
 ### T-BEEP API Example
 
 An experimental Flask service in `api/tbeep_api.py` accepts and stores T-BEEP

--- a/docs/dashboard_usage.md
+++ b/docs/dashboard_usage.md
@@ -17,5 +17,6 @@ Sample data files can be downloaded directly from the repository:
 
 - [docs/examples/wonder_index_log.json](../docs/examples/wonder_index_log.json)
 - [docs/examples/emergence_log.json](../docs/examples/emergence_log.json)
+- [docs/examples/wonder_signals.json](../docs/examples/wonder_signals.json)
 Drift metrics are checked against realignment thresholds and highlighted when thresholds are exceeded. A collaborative **Wonder Signals** text area is available for qualitative notes.
 You can additionally upload a metrics log in JSON format via the sidebar for ad-hoc drift analysis.

--- a/docs/examples/wonder_signals.json
+++ b/docs/examples/wonder_signals.json
@@ -1,0 +1,4 @@
+[
+  {"timestamp": "2024-06-15T12:00:00", "text": "Embraced collaborative exploration of metaphors."},
+  {"timestamp": "2024-06-16T12:00:00", "text": "Surprised by divergent interpretations of \"echoing city\"."}
+]

--- a/docs/examples/wonder_signals.txt
+++ b/docs/examples/wonder_signals.txt
@@ -1,2 +1,0 @@
-2024-06-15T12:00:00 Embraced collaborative exploration of metaphors.
-2024-06-16T12:00:00 Surprised by divergent interpretations of "echoing city".

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -91,7 +91,7 @@ def test_full_pipeline(tmp_path, monkeypatch):
     divergence_log.write_text(
         json.dumps([{"timestamp": ts, "labels": ["a", "b"], "matrix": [[0, 0.1], [0.1, 0]]}])
     )
-    signals_file.write_text(json.dumps([{"timestamp": ts, "wonder_signal": 0.5}]))
+    signals_file.write_text(json.dumps([{"timestamp": ts, "text": "note"}]))
     wonder_index_calculator.main([
         "--drift", str(drift_log),
         "--div", str(divergence_log),

--- a/tests/test_record_wonder.py
+++ b/tests/test_record_wonder.py
@@ -1,0 +1,18 @@
+import json
+import sys
+from pathlib import Path
+from tools import record_wonder
+
+
+def test_record_wonder_appends_json(tmp_path, monkeypatch):
+    file = tmp_path / "signals.json"
+    monkeypatch.setattr(sys, "argv", ["record_wonder.py", "hello", "--file", str(file)])
+    record_wonder.main()
+    data = json.loads(file.read_text())
+    assert data[0]["text"] == "hello"
+
+    monkeypatch.setattr(sys, "argv", ["record_wonder.py", "world", "--file", str(file)])
+    record_wonder.main()
+    data = json.loads(file.read_text())
+    assert len(data) == 2
+

--- a/tests/test_wonder_index_calculator.py
+++ b/tests/test_wonder_index_calculator.py
@@ -1,0 +1,11 @@
+import json
+from tools import wonder_index_calculator as wic
+
+
+def test_load_wonder_signals_text(tmp_path):
+    file = tmp_path / "signals.json"
+    file.write_text(json.dumps([{"timestamp": "2025-01-01T00:00:00", "text": "hi"}]))
+    result = wic.load_wonder_signals(file)
+    assert "2025-01-01T00:00:00" in result
+    assert result["2025-01-01T00:00:00"]["wonder_signal"] == min(len("hi")/100.0, 1.0)
+

--- a/tools/record_wonder.py
+++ b/tools/record_wonder.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Wonder Signal Recorder
-======================
+=======================
 
 Usage:
   python tools/record_wonder.py "My reflection" [--file PATH]
 
-Append a short reflection to ``wonder_signals.txt`` with a UTC timestamp.
+Append a short reflection with a UTC timestamp to ``wonder_signals.json``. Each
+entry is stored as ``{"timestamp": ..., "text": ...}``.
 """
 
 from __future__ import annotations
@@ -13,8 +14,9 @@ from __future__ import annotations
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
+import json
 
-DEFAULT_FILE = Path("docs/examples/wonder_signals.txt")
+DEFAULT_FILE = Path("docs/examples/wonder_signals.json")
 
 
 def main() -> None:
@@ -26,9 +28,22 @@ def main() -> None:
 
     path = args.file
     path.parent.mkdir(parents=True, exist_ok=True)
-    line = f"{datetime.utcnow().isoformat()} {args.text.strip()}\n"
-    with path.open("a", encoding="utf-8") as f:
-        f.write(line)
+
+    data = []
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            if not isinstance(data, list):
+                data = []
+        except Exception:
+            data = []
+
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "text": args.text.strip(),
+    }
+    data.append(entry)
+    path.write_text(json.dumps(data, indent=2))
     print(f"Appended to {path}")
 
 

--- a/tools/wonder_index_calculator.py
+++ b/tools/wonder_index_calculator.py
@@ -73,17 +73,29 @@ def load_divergence(path: Path) -> Dict[str, MetricDict]:
 
 
 def load_wonder_signals(path: Path) -> Dict[str, MetricDict]:
-    """Load optional Wonder Signals JSON (timestamp -> value)."""
+    """Load optional Wonder Signals JSON produced by ``record_wonder.py``."""
     if not path.exists():
         return {}
     with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
+
     result: Dict[str, MetricDict] = {}
+    if not isinstance(data, list):
+        return result
+
     for entry in data:
         ts = entry.get("timestamp")
-        val = entry.get("wonder_signal")
-        if ts and val is not None:
-            result[ts] = {"wonder_signal": float(val)}
+        if ts is None:
+            continue
+        if "wonder_signal" in entry:
+            val = entry.get("wonder_signal")
+            if val is not None:
+                result[ts] = {"wonder_signal": float(val)}
+            continue
+        text = entry.get("text")
+        if text is not None:
+            result[ts] = {"wonder_signal": min(len(text) / 100.0, 1.0)}
+
     return result
 
 


### PR DESCRIPTION
## Summary
- log wonder signals as JSON objects via `record_wonder.py`
- parse new JSON structure in `wonder_index_calculator.py`
- document new behaviour and sample file location
- convert example wonder signals to JSON
- adjust integration test and add new unit tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a273bada4832dad69a8ebfd80c511